### PR TITLE
Refactor sandbox

### DIFF
--- a/AgentSandbox.Core/Importing/FileImportManager.cs
+++ b/AgentSandbox.Core/Importing/FileImportManager.cs
@@ -1,0 +1,73 @@
+using AgentSandbox.Core.FileSystem;
+
+namespace AgentSandbox.Core.Importing;
+
+/// <summary>
+/// Manages all file imports into the sandbox from various sources.
+/// Provides unified copying of files into the virtual filesystem.
+/// Skills are imported as regular files, then discovered via SkillManager.
+/// </summary>
+internal class FileImportManager
+{
+    private readonly FileSystem.FileSystem _fileSystem;
+
+    public FileImportManager(FileSystem.FileSystem fileSystem)
+    {
+        _fileSystem = fileSystem;
+    }
+
+    /// <summary>
+    /// Imports files from a source to a destination path in the sandbox.
+    /// Supports generic files, skills, models, datasets, or any other file-based imports.
+    /// </summary>
+    /// <param name="path">The destination path in the sandbox.</param>
+    /// <param name="source">The file source (filesystem, embedded, in-memory, etc.).</param>
+    /// <exception cref="ArgumentNullException">Path or source is null.</exception>
+    public void Import(string path, IFileSource source)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            throw new ArgumentNullException(nameof(path));
+        if (source == null)
+            throw new ArgumentNullException(nameof(source));
+
+        var files = source.GetFiles().ToList();
+        CopyFiles(path, files);
+    }
+
+    /// <summary>
+    /// Copies files from a collection to a destination directory in the virtual filesystem.
+    /// Creates parent directories as needed.
+    /// </summary>
+    internal void CopyFiles(string destPath, IReadOnlyList<FileData> files)
+    {
+        // Normalize path
+        if (!destPath.StartsWith("/"))
+        {
+            destPath = "/" + destPath;
+        }
+
+        // Create destination directory
+        _fileSystem.CreateDirectory(destPath);
+
+        // Copy all files to virtual filesystem
+        foreach (var file in files)
+        {
+            var filePath = $"{destPath}/{file.RelativePath}";
+
+            // Ensure parent directory exists
+            var lastSlash = filePath.LastIndexOf('/');
+            if (lastSlash > 0)
+            {
+                var parentDir = filePath[..lastSlash];
+                if (parentDir != destPath && !_fileSystem.Exists(parentDir))
+                {
+                    _fileSystem.CreateDirectory(parentDir);
+                }
+            }
+
+            _fileSystem.WriteFile(filePath, file.Content);
+        }
+    }
+}
+
+

--- a/AgentSandbox.Core/Importing/SkillManager.cs
+++ b/AgentSandbox.Core/Importing/SkillManager.cs
@@ -1,0 +1,138 @@
+using System.Text;
+using AgentSandbox.Core.FileSystem;
+using AgentSandbox.Core.Skills;
+
+namespace AgentSandbox.Core.Importing;
+
+/// <summary>
+/// Discovers and loads agent skills from the virtual filesystem.
+/// Skills must be pre-imported via FileImportManager before calling LoadSkills.
+/// Scans skill directories for SKILL.md files, parses metadata, and caches SkillInfo objects.
+/// </summary>
+internal class SkillManager
+{
+    private readonly FileSystem.FileSystem _fileSystem;
+    private readonly List<SkillInfo> _loadedSkills = new();
+
+    public SkillManager(FileSystem.FileSystem fileSystem)
+    {
+        _fileSystem = fileSystem;
+    }
+
+    /// <summary>
+    /// Discovers and loads all skills in the skill base path.
+    /// Each subdirectory under basePath containing SKILL.md becomes a loaded skill.
+    /// Results are cached for subsequent calls to GetSkills() and GetSkillsDescription().
+    /// </summary>
+    /// <param name="basePath">The base path where skills are located (e.g., /.sandbox/skills).</param>
+    /// <returns>List of discovered skill information.</returns>
+    /// <exception cref="ArgumentNullException">BasePath is null or empty.</exception>
+    /// <exception cref="InvalidSkillException">A skill is missing SKILL.md or metadata is invalid.</exception>
+    public IReadOnlyList<SkillInfo> LoadSkills(string basePath)
+    {
+        if (string.IsNullOrWhiteSpace(basePath))
+            throw new ArgumentNullException(nameof(basePath));
+
+        // Ensure base path exists
+        if (!_fileSystem.Exists(basePath))
+            return Array.Empty<SkillInfo>();
+
+        var skills = new List<SkillInfo>();
+
+        // Scan subdirectories for skill definitions
+        try
+        {
+            var entries = _fileSystem.ListDirectory(basePath);
+            foreach (var entryName in entries)
+            {
+                var skillPath = $"{basePath}/{entryName}";
+                
+                // Check if this entry is a directory and contains SKILL.md
+                if (_fileSystem.IsDirectory(skillPath))
+                {
+                    var skillMdPath = $"{skillPath}/SKILL.md";
+                    if (_fileSystem.Exists(skillMdPath))
+                    {
+                        var skillInfo = LoadSkill(entryName, skillPath, skillMdPath);
+                        if (skillInfo != null)
+                        {
+                            skills.Add(skillInfo);
+                        }
+                    }
+                }
+            }
+        }
+        catch (DirectoryNotFoundException)
+        {
+            // BasePath doesn't exist, return empty list
+            return Array.Empty<SkillInfo>();
+        }
+
+        // Cache the loaded skills
+        _loadedSkills.Clear();
+        _loadedSkills.AddRange(skills);
+
+        return skills.AsReadOnly();
+    }
+
+    /// <summary>
+    /// Loads a single skill from its SKILL.md file.
+    /// </summary>
+    private SkillInfo? LoadSkill(string skillName, string skillPath, string skillMdPath)
+    {
+        try
+        {
+            var skillMdContent = _fileSystem.ReadFile(skillMdPath);
+            var metadata = SkillMetadata.Parse(skillMdContent);
+
+            return new SkillInfo
+            {
+                Name = skillName,
+                Description = metadata.Description,
+                Path = skillPath,
+                Metadata = metadata
+            };
+        }
+        catch (InvalidSkillException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidSkillException($"Failed to load skill '{skillName}' from {skillPath}", ex);
+        }
+    }
+
+    /// <summary>
+    /// Gets information about all loaded skills.
+    /// </summary>
+    public IReadOnlyList<SkillInfo> GetSkills() => _loadedSkills.AsReadOnly();
+
+    /// <summary>
+    /// Gets a description of loaded skills for use in AI function descriptions.
+    /// Uses the XML format recommended by agentskills.io specification.
+    /// </summary>
+    public string GetSkillsDescription()
+    {
+        if (_loadedSkills.Count == 0)
+        {
+            return "No skills are currently available.";
+        }
+
+        var sb = new StringBuilder();
+        sb.AppendLine("<available_skills>");
+
+        foreach (var skill in _loadedSkills)
+        {
+            sb.AppendLine("  <skill>");
+            sb.AppendLine($"    <name>{skill.Name}</name>");
+            sb.AppendLine($"    <description>{skill.Description}</description>");
+            sb.AppendLine($"    <location>{skill.Path}/SKILL.md</location>");
+            sb.AppendLine("  </skill>");
+        }
+
+        sb.AppendLine("</available_skills>");
+
+        return sb.ToString();
+    }
+}

--- a/AgentSandbox.Core/Sandbox.cs
+++ b/AgentSandbox.Core/Sandbox.cs
@@ -1,10 +1,10 @@
-using System.Diagnostics;
-using System.Text;
 using AgentSandbox.Core.FileSystem;
 using AgentSandbox.Core.Importing;
 using AgentSandbox.Core.Shell;
 using AgentSandbox.Core.Skills;
 using AgentSandbox.Core.Telemetry;
+using System.Diagnostics;
+using System.Text;
 
 namespace AgentSandbox.Core;
 
@@ -17,29 +17,14 @@ public class Sandbox : IDisposable, IObservableSandbox
     private readonly SandboxShell _shell;
     private readonly SandboxOptions _options;
     private readonly SandboxTelemetryFacade _telemetry;
+    private readonly ObserverManager _observerManager = new();
+    private readonly FileImportManager _fileImportManager;
+    private readonly SkillManager _skillManager;
     private readonly List<ShellResult> _commandHistory = new();
-    private readonly List<SkillInfo> _loadedSkills = new();
-    private readonly List<ISandboxObserver> _observers = new();
-    private readonly object _observerLock = new();
     private readonly Action<string>? _onDisposed;
     private readonly Activity? _sandboxActivity;
     private bool _disposed;
-
     private bool TelemetryEnabled => _options.Telemetry?.Enabled == true;
-
-    public string Id { get; }
-    public DateTime CreatedAt { get; }
-    public DateTime LastActivityAt { get; private set; }
-    
-    /// <summary>
-    /// Gets the current working directory of the sandbox shell.
-    /// </summary>
-    public string CurrentDirectory => _shell.CurrentDirectory;
-    
-    /// <summary>
-    /// Gets a copy of the sandbox options. Modifications to the returned object do not affect the sandbox.
-    /// </summary>
-    public SandboxOptions Options => _options.Clone();
 
     public Sandbox(string? id = null, SandboxOptions? options = null)
         : this(id, options, null)
@@ -51,16 +36,6 @@ public class Sandbox : IDisposable, IObservableSandbox
         Id = id ?? Guid.NewGuid().ToString("N")[..12];
         _options = options ?? new SandboxOptions();
         _onDisposed = onDisposed;
-
-        // Initialize telemetry facade
-        _telemetry = new SandboxTelemetryFacade(_options, Id, NotifyObservers);
-        
-        // Start sandbox-level activity for tracing
-        if (TelemetryEnabled)
-        {
-            _sandboxActivity = SandboxTelemetry.StartSandboxActivity(Id);
-            _telemetry.RecordSandboxCreated();
-        }
         
         // Create filesystem with size limits from options
         var fsOptions = new FileSystemOptions
@@ -69,10 +44,26 @@ public class Sandbox : IDisposable, IObservableSandbox
             MaxFileSize = _options.MaxFileSize,
             MaxNodeCount = _options.MaxNodeCount
         };
+
         _fileSystem = new FileSystem.FileSystem(fsOptions);
+        
+        // Initialize shell and module managers
         _shell = new SandboxShell(_fileSystem);
+        _fileImportManager = new FileImportManager(_fileSystem);
+        _skillManager = new SkillManager(_fileSystem);
+
         CreatedAt = DateTime.UtcNow;
         LastActivityAt = CreatedAt;
+
+        // Initialize telemetry facade
+        _telemetry = new SandboxTelemetryFacade(_options, Id, _observerManager.NotifyObservers);
+        
+        // Start sandbox-level activity for tracing
+        if (TelemetryEnabled)
+        {
+            _sandboxActivity = SandboxTelemetry.StartSandboxActivity(Id);
+            _telemetry.RecordSandboxCreated();
+        }
 
         // Apply initial environment
         foreach (var kvp in _options.Environment)
@@ -93,17 +84,35 @@ public class Sandbox : IDisposable, IObservableSandbox
             _shell.RegisterCommand(cmd);
         }
 
-        // Import files
-        ImportFiles();
+        // Import all files (including skills) from configured sources
+        foreach (var import in _options.Imports)
+        {
+            _fileImportManager.Import(import.Path, import.Source);
+        }
 
-        // Load agent skills
-        LoadSkills();
+        // Discover and load skills from the skill base path
+        _skillManager.LoadSkills(_options.AgentSkills.BasePath);
     }
+
+    #region  Properties
+
+    public string Id { get; }
+
+    public DateTime CreatedAt { get; }
+
+    public DateTime LastActivityAt { get; private set; }
+    
+    /// <summary>
+    /// Gets the current working directory of the sandbox shell.
+    /// </summary>
+    public string CurrentDirectory => _shell.CurrentDirectory;
+
+    #endregion
 
     #region Command Execution
 
     /// <summary>
-    /// Executes a shell command in the sandbox.
+    /// Executes a bash shell command in the sandbox.
     /// </summary>
     public ShellResult Execute(string command)
     {
@@ -133,6 +142,22 @@ public class Sandbox : IDisposable, IObservableSandbox
         {
             activity?.Dispose();
         }
+    }
+
+    /// <summary>
+    /// Gets a description of the bash shell tool.
+    /// Dynamically includes all available commands and extensions.
+    /// </summary>
+    public string GetBashToolDescription()
+    {
+        var sb = new StringBuilder();
+        
+        sb.Append("Run shell commands. ");
+        sb.Append($"Available commands: {string.Join(", ", _shell.GetAvailableCommands())}. ");
+        sb.Append("Run 'help' to list commands or '<command> -h' for detailed help on a specific command. ");
+        sb.Append("Commands use short-style arguments (e.g., -l, -a, -n). ");
+
+        return sb.ToString();
     }
 
     #endregion
@@ -410,125 +435,17 @@ public class Sandbox : IDisposable, IObservableSandbox
     /// <summary>
     /// Gets information about all loaded skills.
     /// </summary>
-    public IReadOnlyList<SkillInfo> GetSkills() => _loadedSkills.AsReadOnly();
+    public IReadOnlyList<SkillInfo> GetSkills() => _skillManager.GetSkills();
 
     /// <summary>
     /// Gets a description of loaded skills for use in AI function descriptions.
     /// Uses the XML format recommended by agentskills.io specification.
     /// </summary>
-    public string GetSkillsDescription()
-    {
-        if (_loadedSkills.Count == 0)
-        {
-            return "No skills are currently available.";
-        }
-
-        var sb = new StringBuilder();
-        sb.AppendLine("<available_skills>");
-
-        foreach (var skill in _loadedSkills)
-        {
-            sb.AppendLine("  <skill>");
-            sb.AppendLine($"    <name>{skill.Name}</name>");
-            sb.AppendLine($"    <description>{skill.Description}</description>");
-            sb.AppendLine($"    <location>{skill.Path}/SKILL.md</location>");
-            sb.AppendLine("  </skill>");
-        }
-
-        sb.AppendLine("</available_skills>");
-
-        return sb.ToString();
-    }
+    public string GetSkillsDescription() => _skillManager.GetSkillsDescription();
     
-    private void LoadSkills()
-    {
-        if (_options.AgentSkills.Skills.Count == 0) return;
-
-        // Create skills base directory
-        _fileSystem.CreateDirectory(_options.AgentSkills.BasePath);
-
-        foreach (var skill in _options.AgentSkills.Skills)
-        {
-            var skillInfo = LoadSkill(skill);
-            _loadedSkills.Add(skillInfo);
-        }
-    }
-
-    private SkillInfo LoadSkill(AgentSkill skill)
-    {
-        // Get all files from the skill source
-        var files = skill.Source.GetFiles().ToList();
-
-        // Find and parse SKILL.md (required)
-        var skillMdFile = files.FirstOrDefault(f => 
-            f.RelativePath.Equals("SKILL.md", StringComparison.OrdinalIgnoreCase));
-        
-        if (skillMdFile == null)
-        {
-            throw new InvalidSkillException("Skill must contain a SKILL.md file");
-        }
-
-        var metadata = SkillMetadata.Parse(skillMdFile.GetContentAsString());
-
-        // Use name from AgentSkill if provided, otherwise from SKILL.md
-        var skillName = skill.Name ?? metadata.Name;
-        var skillPath = $"{_options.AgentSkills.BasePath}/{skillName}";
-
-        // Copy files to the path
-        CopyFilesInternal(skillPath, files);
-
-        return new SkillInfo
-        {
-            Name = skillName,
-            Description = metadata.Description,
-            Path = skillPath,
-            Metadata = metadata
-        };
-    }
-
-    private void ImportFiles()
-    {
-        foreach (var import in _options.Imports)
-        {
-            var files = import.Source.GetFiles().ToList();
-            CopyFilesInternal(import.Path, files);
-        }
-    }
-
-    private void CopyFilesInternal(string destPath, IReadOnlyList<FileData> files)
-    {
-        // Normalize path
-        if (!destPath.StartsWith("/"))
-        {
-            destPath = "/" + destPath;
-        }
-
-        // Create destination directory
-        _fileSystem.CreateDirectory(destPath);
-
-        // Copy all files to virtual filesystem
-        foreach (var file in files)
-        {
-            var filePath = $"{destPath}/{file.RelativePath}";
-            
-            // Ensure parent directory exists
-            var lastSlash = filePath.LastIndexOf('/');
-            if (lastSlash > 0)
-            {
-                var parentDir = filePath[..lastSlash];
-                if (parentDir != destPath && !_fileSystem.Exists(parentDir))
-                {
-                    _fileSystem.CreateDirectory(parentDir);
-                }
-            }
-
-            _fileSystem.WriteFile(filePath, file.Content);
-        }
-    }
-
     #endregion
 
-    #region  Snapshots
+    #region Snapshots
 
     /// <summary>
     /// Creates a snapshot of the entire sandbox state.
@@ -573,22 +490,6 @@ public class Sandbox : IDisposable, IObservableSandbox
     public IReadOnlyList<ShellResult> GetHistory() => _commandHistory.AsReadOnly();
 
     /// <summary>
-    /// Gets a description of the sandbox tool for use in AI function descriptions.
-    /// Dynamically includes all available commands and extensions.
-    /// </summary>
-    public string GetToolDescription()
-    {
-        var sb = new StringBuilder();
-        
-        sb.Append("Run shell commands. ");
-        sb.Append($"Available commands: {string.Join(", ", _shell.GetAvailableCommands())}. ");
-        sb.Append("Run 'help' to list commands or '<command> -h' for detailed help on a specific command. ");
-        sb.Append("Commands use short-style arguments (e.g., -l, -a, -n). ");
-
-        return sb.ToString();
-    }
-
-    /// <summary>
     /// Gets sandbox statistics.
     /// </summary>
     public SandboxStats GetStats() => new()
@@ -611,56 +512,7 @@ public class Sandbox : IDisposable, IObservableSandbox
     /// </summary>
     public IDisposable Subscribe(ISandboxObserver observer)
     {
-        lock (_observerLock)
-        {
-            _observers.Add(observer);
-        }
-
-        return new ObserverUnsubscriber(this, observer);
-    }
-
-    private void Unsubscribe(ISandboxObserver observer)
-    {
-        lock (_observerLock)
-        {
-            _observers.Remove(observer);
-        }
-    }
-
-    private sealed class ObserverUnsubscriber : IDisposable
-    {
-        private readonly Sandbox _sandbox;
-        private readonly ISandboxObserver _observer;
-
-        public ObserverUnsubscriber(Sandbox sandbox, ISandboxObserver observer)
-        {
-            _sandbox = sandbox;
-            _observer = observer;
-        }
-
-        public void Dispose() => _sandbox.Unsubscribe(_observer);
-    }
-
-    private void NotifyObservers(Action<ISandboxObserver> action)
-    {
-        ISandboxObserver[] observers;
-        lock (_observerLock)
-        {
-            if (_observers.Count == 0) return;
-            observers = _observers.ToArray();
-        }
-
-        foreach (var observer in observers)
-        {
-            try
-            {
-                action(observer);
-            }
-            catch
-            {
-                // Don't let observer exceptions affect sandbox operation
-            }
-        }
+        return _observerManager.Subscribe(observer);
     }
 
     #endregion
@@ -690,11 +542,7 @@ public class Sandbox : IDisposable, IObservableSandbox
         }
 
         _commandHistory.Clear();
-        
-        lock (_observerLock)
-        {
-            _observers.Clear();
-        }
+        _observerManager.Clear();
         
         // Notify manager to remove reference
         _onDisposed?.Invoke(Id);

--- a/AgentSandbox.Core/SandboxOptions.cs
+++ b/AgentSandbox.Core/SandboxOptions.cs
@@ -38,7 +38,8 @@ public class SandboxOptions
     public IReadOnlyList<FileImportOptions> Imports { get; set; } = [];
 
     /// <summary>
-    /// Agent skills configuration. Skills are loaded at initialization.
+    /// Agent skills configuration. Skills are discovered from the BasePath after file imports.
+    /// Skills should be imported to subdirectories under BasePath via FileImportOptions.
     /// </summary>
     public AgentSkillOptions AgentSkills { get; set; } = new();
 
@@ -62,7 +63,6 @@ public class SandboxOptions
         Imports = Imports.ToArray(),
         AgentSkills = new AgentSkillOptions
         {
-            Skills = AgentSkills.Skills.ToArray(),
             BasePath = AgentSkills.BasePath
         },
         Telemetry = Telemetry

--- a/AgentSandbox.Core/Skills/AgentSkillOptions.cs
+++ b/AgentSandbox.Core/Skills/AgentSkillOptions.cs
@@ -2,17 +2,15 @@ namespace AgentSandbox.Core.Skills;
 
 /// <summary>
 /// Configuration options for agent skills.
+/// Skills are imported via FileImportOptions into the sandbox filesystem,
+/// then discovered and loaded as SkillInfo objects.
 /// </summary>
 public class AgentSkillOptions
 {
     /// <summary>
-    /// Agent skills to load into the sandbox filesystem.
-    /// Skills are copied to {BasePath}/{name}/ at initialization.
-    /// </summary>
-    public IReadOnlyList<AgentSkill> Skills { get; set; } = [];
-
-    /// <summary>
-    /// Base path where skills are installed. Default: /.sandbox/skills
+    /// Base path where skills are located after import. Default: /.sandbox/skills
+    /// Skills should be imported to paths under this BasePath via FileImportOptions.
     /// </summary>
     public string BasePath { get; set; } = "/.sandbox/skills";
 }
+

--- a/AgentSandbox.Core/Telemetry/ObserverManager.cs
+++ b/AgentSandbox.Core/Telemetry/ObserverManager.cs
@@ -1,0 +1,92 @@
+using AgentSandbox.Core.Telemetry;
+
+namespace AgentSandbox.Core;
+
+/// <summary>
+/// Manages observer subscriptions and event notifications.
+/// Provides thread-safe observer pattern implementation.
+/// </summary>
+public class ObserverManager
+{
+    private readonly List<ISandboxObserver> _observers = new();
+    private readonly object _observerLock = new();
+
+    /// <summary>
+    /// Subscribes an observer to receive sandbox events.
+    /// </summary>
+    /// <param name="observer">The observer to subscribe.</param>
+    /// <returns>A disposable token that unsubscribes the observer when disposed.</returns>
+    public IDisposable Subscribe(ISandboxObserver observer)
+    {
+        lock (_observerLock)
+        {
+            _observers.Add(observer);
+        }
+
+        return new ObserverUnsubscriber(this, observer);
+    }
+
+    /// <summary>
+    /// Notifies all subscribed observers by invoking the provided action.
+    /// Exceptions thrown by observers are swallowed to prevent cascading failures.
+    /// </summary>
+    /// <param name="action">The action to invoke for each observer.</param>
+    public void NotifyObservers(Action<ISandboxObserver> action)
+    {
+        ISandboxObserver[] observers;
+        lock (_observerLock)
+        {
+            if (_observers.Count == 0) return;
+            observers = _observers.ToArray();
+        }
+
+        foreach (var observer in observers)
+        {
+            try
+            {
+                action(observer);
+            }
+            catch
+            {
+                // Don't let observer exceptions affect sandbox operation
+            }
+        }
+    }
+
+    /// <summary>
+    /// Unsubscribes an observer from receiving events.
+    /// </summary>
+    /// <param name="observer">The observer to unsubscribe.</param>
+    private void Unsubscribe(ISandboxObserver observer)
+    {
+        lock (_observerLock)
+        {
+            _observers.Remove(observer);
+        }
+    }
+
+    /// <summary>
+    /// Clears all subscribed observers.
+    /// </summary>
+    public void Clear()
+    {
+        lock (_observerLock)
+        {
+            _observers.Clear();
+        }
+    }
+
+    private sealed class ObserverUnsubscriber : IDisposable
+    {
+        private readonly ObserverManager _manager;
+        private readonly ISandboxObserver _observer;
+
+        public ObserverUnsubscriber(ObserverManager manager, ISandboxObserver observer)
+        {
+            _manager = manager;
+            _observer = observer;
+        }
+
+        public void Dispose() => _manager.Unsubscribe(_observer);
+    }
+}

--- a/AgentSandbox.Extensions/Extensions.cs
+++ b/AgentSandbox.Extensions/Extensions.cs
@@ -40,7 +40,7 @@ public static class Extensions
                 return $"Error: {result.Stderr}";
             },
             name: "bash_shell",
-            description: sandbox.GetToolDescription());
+            description: sandbox.GetBashToolDescription());
     }
 
     /// <summary>

--- a/samples/InteractiveAgent/Program.cs
+++ b/samples/InteractiveAgent/Program.cs
@@ -1,5 +1,6 @@
 using AgentSandbox.InteractiveAgent;
 using AgentSandbox.Core;
+using AgentSandbox.Core.Importing;
 using AgentSandbox.Core.Shell;
 using AgentSandbox.Core.Shell.Extensions;
 using AgentSandbox.Core.Skills;
@@ -31,13 +32,22 @@ using var sandbox = new Sandbox(options: new SandboxOptions
     {
         new GitCommand()
     },
+    Imports =
+    [
+        new FileImportOptions
+        {
+            Path = "/.sandbox/skills/brainstorming",
+            Source = new FileSystemSource(Path.Combine(skillsPath, "brainstorming"))
+        },
+        new FileImportOptions
+        {
+            Path = "/.sandbox/skills/executing-plans",
+            Source = new FileSystemSource(Path.Combine(skillsPath, "executing-plans"))
+        }
+    ],
     AgentSkills = new AgentSkillOptions
     {
-        Skills = 
-        [
-            AgentSkill.FromPath(Path.Combine(skillsPath, "brainstorming")),
-            AgentSkill.FromPath(Path.Combine(skillsPath, "executing-plans"))
-        ]
+        BasePath = "/.sandbox/skills"
     },
     Telemetry = new SandboxTelemetryOptions
     {

--- a/samples/InteractiveSandbox/Program.cs
+++ b/samples/InteractiveSandbox/Program.cs
@@ -1,4 +1,5 @@
 ﻿using AgentSandbox.Core;
+using AgentSandbox.Core.Importing;
 using AgentSandbox.Core.Shell;
 using AgentSandbox.Core.Shell.Extensions;
 using AgentSandbox.Core.Skills;
@@ -16,13 +17,22 @@ Sandbox sandbox = new Sandbox(options: new SandboxOptions
         new JqCommand(),
         new GitCommand()
     },
+    Imports =
+    [
+        new FileImportOptions
+        {
+            Path = "/.sandbox/skills/brainstorming",
+            Source = new FileSystemSource(Path.Combine(skillsPath, "brainstorming"))
+        },
+        new FileImportOptions
+        {
+            Path = "/.sandbox/skills/executing-plans",
+            Source = new FileSystemSource(Path.Combine(skillsPath, "executing-plans"))
+        }
+    ],
     AgentSkills = new AgentSkillOptions
     {
-        Skills = 
-        [
-            AgentSkill.FromPath(Path.Combine(skillsPath, "brainstorming")),
-            AgentSkill.FromPath(Path.Combine(skillsPath, "executing-plans"))
-        ]
+        BasePath = "/.sandbox/skills"
     },
     Telemetry = new SandboxTelemetryOptions
     {

--- a/tests/AgentSandbox.Tests/AgentSkillsTests.cs
+++ b/tests/AgentSandbox.Tests/AgentSkillsTests.cs
@@ -23,7 +23,15 @@ public class AgentSkillsTests
         var skillPath = Path.Combine(TestSkillsPath, "test-skill");
         var options = new SandboxOptions
         {
-            AgentSkills = new AgentSkillOptions { Skills = [AgentSkill.FromPath(skillPath)] }
+            Imports =
+            [
+                new FileImportOptions
+                {
+                    Path = "/.sandbox/skills/test-skill",
+                    Source = new FileSystemSource(skillPath)
+                }
+            ],
+            AgentSkills = new AgentSkillOptions { BasePath = "/.sandbox/skills" }
         };
 
         var sandbox = new Sandbox(options: options);
@@ -41,7 +49,15 @@ public class AgentSkillsTests
         var skillPath = Path.Combine(TestSkillsPath, "test-skill");
         var options = new SandboxOptions
         {
-            AgentSkills = new AgentSkillOptions { Skills = [AgentSkill.FromPath(skillPath)] }
+            Imports =
+            [
+                new FileImportOptions
+                {
+                    Path = "/.sandbox/skills/test-skill",
+                    Source = new FileSystemSource(skillPath)
+                }
+            ],
+            AgentSkills = new AgentSkillOptions { BasePath = "/.sandbox/skills" }
         };
 
         var sandbox = new Sandbox(options: options);
@@ -60,7 +76,15 @@ public class AgentSkillsTests
         var skillPath = Path.Combine(TestSkillsPath, "test-skill");
         var options = new SandboxOptions
         {
-            AgentSkills = new AgentSkillOptions { Skills = [AgentSkill.FromPath(skillPath)] }
+            Imports =
+            [
+                new FileImportOptions
+                {
+                    Path = "/.sandbox/skills/test-skill",
+                    Source = new FileSystemSource(skillPath)
+                }
+            ],
+            AgentSkills = new AgentSkillOptions { BasePath = "/.sandbox/skills" }
         };
 
         var sandbox = new Sandbox(options: options);
@@ -75,7 +99,15 @@ public class AgentSkillsTests
         var skillPath = Path.Combine(TestSkillsPath, "test-skill");
         var options = new SandboxOptions
         {
-            AgentSkills = new AgentSkillOptions { Skills = [AgentSkill.FromPath(skillPath)] }
+            Imports =
+            [
+                new FileImportOptions
+                {
+                    Path = "/.sandbox/skills/test-skill",
+                    Source = new FileSystemSource(skillPath)
+                }
+            ],
+            AgentSkills = new AgentSkillOptions { BasePath = "/.sandbox/skills" }
         };
 
         var sandbox = new Sandbox(options: options);
@@ -93,7 +125,15 @@ public class AgentSkillsTests
         var skillPath = Path.Combine(TestSkillsPath, "test-skill");
         var options = new SandboxOptions
         {
-            AgentSkills = new AgentSkillOptions { Skills = [AgentSkill.FromPath(skillPath)] }
+            Imports =
+            [
+                new FileImportOptions
+                {
+                    Path = "/.sandbox/skills/test-skill",
+                    Source = new FileSystemSource(skillPath)
+                }
+            ],
+            AgentSkills = new AgentSkillOptions { BasePath = "/.sandbox/skills" }
         };
 
         var sandbox = new Sandbox(options: options);
@@ -110,7 +150,15 @@ public class AgentSkillsTests
         var skillPath = Path.Combine(TestSkillsPath, "test-skill");
         var options = new SandboxOptions
         {
-            AgentSkills = new AgentSkillOptions { Skills = [AgentSkill.FromPath(skillPath)] }
+            Imports =
+            [
+                new FileImportOptions
+                {
+                    Path = "/.sandbox/skills/test-skill",
+                    Source = new FileSystemSource(skillPath)
+                }
+            ],
+            AgentSkills = new AgentSkillOptions { BasePath = "/.sandbox/skills" }
         };
 
         var sandbox = new Sandbox(options: options);
@@ -126,16 +174,25 @@ public class AgentSkillsTests
     public void Sandbox_LoadsMultipleSkills()
     {
         var skillPath = Path.Combine(TestSkillsPath, "test-skill");
-        
-        // Create a second skill using in-memory source
-        var skill2 = AgentSkill.FromFiles(new Dictionary<string, string>
-        {
-            ["SKILL.md"] = "---\nname: temp-skill\ndescription: Temporary skill\n---\n\n# Temp Skill"
-        });
-
         var options = new SandboxOptions
         {
-            AgentSkills = new AgentSkillOptions { Skills = [AgentSkill.FromPath(skillPath), skill2] }
+            Imports =
+            [
+                new FileImportOptions
+                {
+                    Path = "/.sandbox/skills/test-skill",
+                    Source = new FileSystemSource(skillPath)
+                },
+                new FileImportOptions
+                {
+                    Path = "/.sandbox/skills/temp-skill",
+                    Source = new InMemorySource(new Dictionary<string, string>
+                    {
+                        ["SKILL.md"] = "---\nname: temp-skill\ndescription: Temporary skill\n---\n\n# Temp Skill"
+                    })
+                }
+            ],
+            AgentSkills = new AgentSkillOptions { BasePath = "/.sandbox/skills" }
         };
 
         var sandbox = new Sandbox(options: options);
@@ -158,10 +215,17 @@ public class AgentSkillsTests
         var skillPath = Path.Combine(TestSkillsPath, "test-skill");
         var options = new SandboxOptions
         {
+            Imports =
+            [
+                new FileImportOptions
+                {
+                    Path = "/custom/skills/test-skill",
+                    Source = new FileSystemSource(skillPath)
+                }
+            ],
             AgentSkills = new AgentSkillOptions
             {
-                BasePath = "/custom/skills",
-                Skills = [AgentSkill.FromPath(skillPath)]
+                BasePath = "/custom/skills"
             }
         };
 
@@ -175,31 +239,19 @@ public class AgentSkillsTests
     }
 
     [Fact]
-    public void SandboxOptions_Clone_IncludesSkills()
+    public void SandboxOptions_Clone_IncludesBasePath()
     {
-        var skill1 = AgentSkill.FromFiles(new Dictionary<string, string>
-        {
-            ["SKILL.md"] = "---\nname: skill1\ndescription: Skill 1\n---\n"
-        });
-        var skill2 = AgentSkill.FromFiles(new Dictionary<string, string>
-        {
-            ["SKILL.md"] = "---\nname: skill2\ndescription: Skill 2\n---\n"
-        });
-
         var options = new SandboxOptions
         {
             AgentSkills = new AgentSkillOptions
             {
-                Skills = [skill1, skill2],
                 BasePath = "/custom/path"
             }
         };
 
         var clone = options.Clone();
 
-        Assert.Equal(2, clone.AgentSkills.Skills.Count);
         Assert.Equal("/custom/path", clone.AgentSkills.BasePath);
-        Assert.NotSame(options.AgentSkills.Skills, clone.AgentSkills.Skills);
     }
 
     [Fact]
@@ -220,21 +272,6 @@ public class AgentSkillsTests
         });
 
         Assert.IsType<InMemorySource>(skill.Source);
-    }
-
-    [Fact]
-    public void AgentSkill_NameOverride_UsesProvidedName()
-    {
-        var skill = AgentSkill.FromFiles(new Dictionary<string, string>
-        {
-            ["SKILL.md"] = "---\nname: original-name\ndescription: Test\n---\n"
-        }, name: "override-name");
-
-        var options = new SandboxOptions { AgentSkills = new AgentSkillOptions { Skills = [skill] } };
-        var sandbox = new Sandbox(options: options);
-
-        var loaded = sandbox.GetSkills()[0];
-        Assert.Equal("override-name", loaded.Name);
     }
 
     [Fact]
@@ -270,19 +307,6 @@ public class AgentSkillsTests
         var content = "# No frontmatter here";
         
         Assert.Throws<InvalidSkillException>(() => SkillMetadata.Parse(content));
-    }
-
-    [Fact]
-    public void Sandbox_ThrowsOnMissingSkillMd()
-    {
-        var skill = AgentSkill.FromFiles(new Dictionary<string, string>
-        {
-            ["README.md"] = "No SKILL.md here"
-        });
-
-        var options = new SandboxOptions { AgentSkills = new AgentSkillOptions { Skills = [skill] } };
-        
-        Assert.Throws<InvalidSkillException>(() => new Sandbox(options: options));
     }
 
     [Fact]


### PR DESCRIPTION
Consolidate skill operations in SkillManager

   Move skill state management (_loadedSkills) and operations (GetSkills,
   GetSkillsDescription) from Sandbox to SkillManager, centralizing all skill-
   related concerns in a single manager class.

   CHANGES:
   - SkillManager now owns _loadedSkills cache and populates it during LoadSkills()
   - Added GetSkills() to return cached skill information
   - Added GetSkillsDescription() to generate XML skill descriptions
   - Sandbox delegates skill queries to SkillManager instead of managing state
   - Removed _loadedSkills field from Sandbox
   - Simplified Sandbox constructor - no longer collects skills manually

   ARCHITECTURE:
   Sandbox now purely orchestrates three specialized managers:
   - FileImportManager: handles file imports from any source
   - SkillManager: discovers, caches, and describes skills
   - ObserverManager: manages event subscriptions