### PR TITLE
Improve AgentSkill coverage and factory validation contracts

### DIFF
--- a/AgentSandbox.Core/README.md
+++ b/AgentSandbox.Core/README.md
@@ -185,6 +185,8 @@ sandbox.Execute("sh /skills/python-dev/scripts/setup.sh");
 
 `GetSkills()` returns a cache snapshot of the skills discovered during the most recent discovery pass (performed during sandbox initialization after configured imports are applied). If the configured `AgentSkills.BasePath` is missing or inaccessible, discovery returns an empty result and clears previously loaded skills to prevent stale skill exposure.
 
+`AgentSkill` factory helpers (`FromPath`, `FromAssembly`, `FromFiles`, `FromSource`) validate required inputs and throw argument exceptions for null/blank values before creating source adapters.
+
 ## Built-in Commands
 
 | Command | Description |

--- a/AgentSandbox.Core/Skills/AgentSkill.cs
+++ b/AgentSandbox.Core/Skills/AgentSkill.cs
@@ -25,8 +25,13 @@ public class AgentSkill
     /// </summary>
     /// <param name="path">Path to the skill folder containing SKILL.md.</param>
     /// <param name="name">Optional name override. If not provided, uses name from SKILL.md.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="path"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="path"/> is empty or whitespace.</exception>
+    /// <exception cref="DirectoryNotFoundException">Thrown when the directory at <paramref name="path"/> does not exist.</exception>
     public static AgentSkill FromPath(string path, string? name = null)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
         return new AgentSkill
         {
             Name = name,
@@ -43,8 +48,13 @@ public class AgentSkill
     /// Resources should be embedded with names like "MyApp.Skills.PythonDev.SKILL.md".
     /// </param>
     /// <param name="name">Optional name override. If not provided, uses name from SKILL.md.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="assembly"/> or <paramref name="resourcePrefix"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="resourcePrefix"/> is empty or whitespace.</exception>
     public static AgentSkill FromAssembly(Assembly assembly, string resourcePrefix, string? name = null)
     {
+        ArgumentNullException.ThrowIfNull(assembly);
+        ArgumentException.ThrowIfNullOrWhiteSpace(resourcePrefix);
+
         return new AgentSkill
         {
             Name = name,
@@ -57,8 +67,11 @@ public class AgentSkill
     /// </summary>
     /// <param name="files">Dictionary of relative path to file content.</param>
     /// <param name="name">Optional name override. If not provided, uses name from SKILL.md.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="files"/> is <see langword="null"/>.</exception>
     public static AgentSkill FromFiles(IDictionary<string, string> files, string? name = null)
     {
+        ArgumentNullException.ThrowIfNull(files);
+
         return new AgentSkill
         {
             Name = name,
@@ -71,8 +84,11 @@ public class AgentSkill
     /// </summary>
     /// <param name="source">The file source.</param>
     /// <param name="name">Optional name override. If not provided, uses name from SKILL.md.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="source"/> is <see langword="null"/>.</exception>
     public static AgentSkill FromSource(IFileSource source, string? name = null)
     {
+        ArgumentNullException.ThrowIfNull(source);
+
         return new AgentSkill
         {
             Name = name,

--- a/tests/AgentSandbox.Tests/AgentSkillTests.cs
+++ b/tests/AgentSandbox.Tests/AgentSkillTests.cs
@@ -1,0 +1,74 @@
+using AgentSandbox.Core.Importing;
+using AgentSandbox.Core.Skills;
+
+namespace AgentSandbox.Tests;
+
+public class AgentSkillTests
+{
+    private static readonly string TestSkillsPath = Path.Combine(
+        AppContext.BaseDirectory, "..", "..", "..", "TestSkills");
+
+    [Fact]
+    public void FromAssembly_CreatesEmbeddedSource_AndPreservesName()
+    {
+        var skill = AgentSkill.FromAssembly(typeof(AgentSkillTests).Assembly, "AgentSandbox.Tests.TestResources.Embedded.Valid", "embedded-skill");
+
+        Assert.Equal("embedded-skill", skill.Name);
+        Assert.IsType<EmbeddedSource>(skill.Source);
+    }
+
+    [Fact]
+    public void FromSource_UsesProvidedSource_AndPreservesName()
+    {
+        var source = new InMemorySource().AddFile("SKILL.md", "---\nname: source-test\ndescription: Source test\n---\n");
+
+        var skill = AgentSkill.FromSource(source, "from-source");
+
+        Assert.Equal("from-source", skill.Name);
+        Assert.Same(source, skill.Source);
+    }
+
+    [Fact]
+    public void FromPath_NullOrWhitespacePath_ThrowsExpectedArgumentExceptions()
+    {
+        Assert.Throws<ArgumentNullException>(() => AgentSkill.FromPath(null!));
+        Assert.Throws<ArgumentException>(() => AgentSkill.FromPath(""));
+        Assert.Throws<ArgumentException>(() => AgentSkill.FromPath("   "));
+    }
+
+    [Fact]
+    public void FromPath_MissingDirectory_ThrowsDirectoryNotFoundException()
+    {
+        var missingPath = Path.Combine(TestSkillsPath, "does-not-exist");
+
+        Assert.Throws<DirectoryNotFoundException>(() => AgentSkill.FromPath(missingPath));
+    }
+
+    [Fact]
+    public void FromAssembly_NullAssembly_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => AgentSkill.FromAssembly(null!, "prefix"));
+    }
+
+    [Fact]
+    public void FromAssembly_NullOrWhitespacePrefix_ThrowsExpectedArgumentExceptions()
+    {
+        var assembly = typeof(AgentSkillTests).Assembly;
+
+        Assert.Throws<ArgumentNullException>(() => AgentSkill.FromAssembly(assembly, null!));
+        Assert.Throws<ArgumentException>(() => AgentSkill.FromAssembly(assembly, ""));
+        Assert.Throws<ArgumentException>(() => AgentSkill.FromAssembly(assembly, "   "));
+    }
+
+    [Fact]
+    public void FromFiles_NullFiles_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => AgentSkill.FromFiles(null!));
+    }
+
+    [Fact]
+    public void FromSource_NullSource_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => AgentSkill.FromSource(null!));
+    }
+}


### PR DESCRIPTION
Closes #131

## Summary
- add focused AgentSkill factory coverage for source wiring, boundary cases, and validation contracts
- add argument validation guards to AgentSkill factory methods for null/whitespace inputs
- document AgentSkill factory exception behavior in AgentSandbox.Core README and XML method docs

## Verification
- dotnet test tests/AgentSandbox.Tests/AgentSandbox.Tests.csproj --filter "FullyQualifiedName~AgentSkillTests|FullyQualifiedName~AgentSkillsTests"
- dotnet test AgentSandbox.sln