### PR TITLE
Centralize multi-file command failure policy

### DIFF
--- a/AgentSandbox.Core/README.md
+++ b/AgentSandbox.Core/README.md
@@ -213,6 +213,16 @@ sandbox.Execute("sh /skills/python-dev/scripts/setup.sh");
 - Glob patterns: `*.txt`, `src/**/*.cs`
 - Shell scripts: `sh script.sh` or `./script.sh`
 
+### Multi-file Failure Policy Matrix
+
+Multi-target command behavior is intentionally policy-driven through shared failure handling in shell command implementations:
+
+| Command group | Commands | Failure strategy | Partial stdout on error | Side effects before failure |
+|---|---|---|---|---|
+| Read-oriented | `cat`, `head`, `tail`, `wc`, `grep`, `ls` | Fail fast on first failing input | Preserved for already-processed inputs | N/A |
+| Mutating copy/move | `cp`, `mv` | Fail fast on first failing input | None | Preserved (already-applied changes are not rolled back) |
+| Mutating delete | `rm` | Fail fast by default; `-f` continues past missing paths | None | Preserved (already-deleted paths stay deleted) |
+
 **Not Supported:**
 - Pipelines (`|`) - use file arguments instead: `grep pattern file.txt`
 - Command chaining with `||` - run fallback commands separately or use scripts

--- a/AgentSandbox.Core/Shell/Commands/CatCommand.cs
+++ b/AgentSandbox.Core/Shell/Commands/CatCommand.cs
@@ -18,12 +18,10 @@ public class CatCommand : IShellCommand
         foreach (var file in args)
         {
             if (!ShellCommandFileGuards.TryResolveReadableFilePath(context, Name, file, out var path, out var errorMessage))
-                return new ShellResult
-                {
-                    ExitCode = 1,
-                    Stdout = string.Join("\n", parts),
-                    Stderr = errorMessage
-                };
+                return MultiTargetCommandFailurePolicy.FailFast(
+                    errorMessage,
+                    args.Length,
+                    () => string.Join("\n", parts));
 
             // Use ReadFile() - IFileSystem handles UTF-8 decoding, no manual conversion needed
             parts.Add(context.FileSystem.ReadFile(path));

--- a/AgentSandbox.Core/Shell/Commands/CpCommand.cs
+++ b/AgentSandbox.Core/Shell/Commands/CpCommand.cs
@@ -32,10 +32,14 @@ public class CpCommand : IShellCommand
             var srcPath = context.ResolvePath(src);
             
             if (!context.FileSystem.Exists(srcPath))
-                return ShellResult.Error($"cp: cannot stat '{src}': No such file or directory");
+                return MultiTargetCommandFailurePolicy.FailFast(
+                    $"cp: cannot stat '{src}': No such file or directory",
+                    sources.Count);
 
             if (context.FileSystem.IsDirectory(srcPath) && !recursive)
-                return ShellResult.Error($"cp: -r not specified; omitting directory '{src}'");
+                return MultiTargetCommandFailurePolicy.FailFast(
+                    $"cp: -r not specified; omitting directory '{src}'",
+                    sources.Count);
 
             var targetPath = context.FileSystem.IsDirectory(dest) 
                 ? dest + "/" + FileSystemPath.GetName(srcPath) 

--- a/AgentSandbox.Core/Shell/Commands/GrepCommand.cs
+++ b/AgentSandbox.Core/Shell/Commands/GrepCommand.cs
@@ -225,7 +225,10 @@ public class GrepCommand : IShellCommand
             }
             catch (FileNotFoundException)
             {
-                return ShellResult.Error($"grep: {displayPath}: No such file or directory");
+                return MultiTargetCommandFailurePolicy.FailFast(
+                    $"grep: {displayPath}: No such file or directory",
+                    filePaths.Count,
+                    () => output.ToString().TrimEnd());
             }
         }
 

--- a/AgentSandbox.Core/Shell/Commands/HeadCommand.cs
+++ b/AgentSandbox.Core/Shell/Commands/HeadCommand.cs
@@ -46,7 +46,10 @@ public class HeadCommand : IShellCommand
         foreach (var p in paths)
         {
             if (!ShellCommandFileGuards.TryResolveReadableFilePath(context, Name, p, out var path, out var errorMessage))
-                return ShellResult.Error(errorMessage);
+                return MultiTargetCommandFailurePolicy.FailFast(
+                    errorMessage,
+                    paths.Count,
+                    () => output.ToString().TrimEnd());
             int? endLine = maxLines == int.MaxValue ? null : maxLines + 1;
 
             var count = 0;

--- a/AgentSandbox.Core/Shell/Commands/LsCommand.cs
+++ b/AgentSandbox.Core/Shell/Commands/LsCommand.cs
@@ -42,7 +42,10 @@ public class LsCommand : IShellCommand
             
             if (!context.FileSystem.Exists(path))
             {
-                return ShellResult.Error($"ls: cannot access '{p}': No such file or directory");
+                return MultiTargetCommandFailurePolicy.FailFast(
+                    $"ls: cannot access '{p}': No such file or directory",
+                    paths.Count,
+                    () => output.ToString().TrimEnd());
             }
 
             if (recursive)

--- a/AgentSandbox.Core/Shell/Commands/MultiTargetCommandFailurePolicy.cs
+++ b/AgentSandbox.Core/Shell/Commands/MultiTargetCommandFailurePolicy.cs
@@ -1,0 +1,22 @@
+namespace AgentSandbox.Core.Shell.Commands;
+
+internal static class MultiTargetCommandFailurePolicy
+{
+    public static ShellResult FailFast(
+        string errorMessage,
+        int targetCount,
+        Func<string>? partialStdoutFactory = null)
+    {
+        if (targetCount > 1 && partialStdoutFactory is not null)
+        {
+            return new ShellResult
+            {
+                ExitCode = 1,
+                Stderr = errorMessage,
+                Stdout = partialStdoutFactory()
+            };
+        }
+
+        return ShellResult.Error(errorMessage);
+    }
+}

--- a/AgentSandbox.Core/Shell/Commands/MvCommand.cs
+++ b/AgentSandbox.Core/Shell/Commands/MvCommand.cs
@@ -26,7 +26,9 @@ public class MvCommand : IShellCommand
             var srcPath = context.ResolvePath(src);
             
             if (!context.FileSystem.Exists(srcPath))
-                return ShellResult.Error($"mv: cannot stat '{src}': No such file or directory");
+                return MultiTargetCommandFailurePolicy.FailFast(
+                    $"mv: cannot stat '{src}': No such file or directory",
+                    sources.Count);
 
             var targetPath = context.FileSystem.IsDirectory(dest) 
                 ? dest + "/" + FileSystemPath.GetName(srcPath) 

--- a/AgentSandbox.Core/Shell/Commands/RmCommand.cs
+++ b/AgentSandbox.Core/Shell/Commands/RmCommand.cs
@@ -31,7 +31,9 @@ public class RmCommand : IShellCommand
             if (!context.FileSystem.Exists(path))
             {
                 if (!force)
-                    return ShellResult.Error($"rm: cannot remove '{p}': No such file or directory");
+                    return MultiTargetCommandFailurePolicy.FailFast(
+                        $"rm: cannot remove '{p}': No such file or directory",
+                        paths.Count);
                 continue;
             }
 
@@ -41,7 +43,9 @@ public class RmCommand : IShellCommand
             }
             catch (InvalidOperationException ex)
             {
-                return ShellResult.Error($"rm: {ex.Message}");
+                return MultiTargetCommandFailurePolicy.FailFast(
+                    $"rm: {ex.Message}",
+                    paths.Count);
             }
         }
 

--- a/AgentSandbox.Core/Shell/Commands/TailCommand.cs
+++ b/AgentSandbox.Core/Shell/Commands/TailCommand.cs
@@ -54,7 +54,10 @@ public class TailCommand : IShellCommand
         foreach (var p in paths)
         {
             if (!ShellCommandFileGuards.TryResolveReadableFilePath(context, Name, p, out var path, out var errorMessage))
-                return ShellResult.Error(errorMessage);
+                return MultiTargetCommandFailurePolicy.FailFast(
+                    errorMessage,
+                    paths.Count,
+                    () => output.ToString().TrimEnd());
             
             // Use ring buffer to keep last N lines - avoids full string[] allocation
             var buffer = new string[maxLines];

--- a/AgentSandbox.Core/Shell/Commands/WcCommand.cs
+++ b/AgentSandbox.Core/Shell/Commands/WcCommand.cs
@@ -24,7 +24,10 @@ public class WcCommand : IShellCommand
         foreach (var p in paths)
         {
             if (!ShellCommandFileGuards.TryResolveReadableFilePath(context, Name, p, out var path, out var errorMessage))
-                return ShellResult.Error(errorMessage);
+                return MultiTargetCommandFailurePolicy.FailFast(
+                    errorMessage,
+                    paths.Count,
+                    () => output.ToString().TrimEnd());
 
             var fileBytes = context.FileSystem.ReadFileBytes(path);
             var fileContent = Encoding.UTF8.GetString(fileBytes);

--- a/tests/AgentSandbox.Tests/SandboxShellTests.cs
+++ b/tests/AgentSandbox.Tests/SandboxShellTests.cs
@@ -142,6 +142,20 @@ public class SandboxShellTests
     }
 
     [Fact]
+    public void Ls_MultiplePaths_LaterFailure_KeepsPriorOutputBeforeFailure()
+    {
+        _fs.WriteFile("/dir1/a.txt", "a");
+        _fs.WriteFile("/dir2/b.txt", "b");
+
+        var result = _shell.Execute("ls /dir1 /missing /dir2");
+
+        Assert.False(result.Success);
+        Assert.Contains("a.txt", result.Stdout, StringComparison.Ordinal);
+        Assert.DoesNotContain("b.txt", result.Stdout, StringComparison.Ordinal);
+        Assert.Contains("missing", result.Stderr, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Rm_RemovesFile()
     {
         _fs.WriteFile("/delete.txt", "x");
@@ -161,6 +175,33 @@ public class SandboxShellTests
         
         Assert.True(result.Success);
         Assert.False(_fs.Exists("/dir"));
+    }
+
+    [Fact]
+    public void Rm_MultiplePaths_LaterFailure_KeepsEarlierDelete()
+    {
+        _fs.WriteFile("/a.txt", "a");
+        _fs.WriteFile("/b.txt", "b");
+
+        var result = _shell.Execute("rm /a.txt /missing.txt /b.txt");
+
+        Assert.False(result.Success);
+        Assert.False(_fs.Exists("/a.txt"));
+        Assert.True(_fs.Exists("/b.txt"));
+        Assert.Contains("missing.txt", result.Stderr, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Rm_Force_MultiplePaths_SkipsMissingAndContinues()
+    {
+        _fs.WriteFile("/a.txt", "a");
+        _fs.WriteFile("/b.txt", "b");
+
+        var result = _shell.Execute("rm -f /a.txt /missing.txt /b.txt");
+
+        Assert.True(result.Success);
+        Assert.False(_fs.Exists("/a.txt"));
+        Assert.False(_fs.Exists("/b.txt"));
     }
 
     [Fact]
@@ -225,6 +266,22 @@ public class SandboxShellTests
     }
 
     [Fact]
+    public void Mv_MultipleSources_LaterFailure_KeepsEarlierMovedFile()
+    {
+        _fs.WriteFile("/s1.txt", "one");
+        _fs.WriteFile("/s2.txt", "two");
+        _fs.CreateDirectory("/dest");
+
+        var result = _shell.Execute("mv /s1.txt /missing.txt /s2.txt /dest");
+
+        Assert.False(result.Success);
+        Assert.True(_fs.Exists("/dest/s1.txt"));
+        Assert.False(_fs.Exists("/s1.txt"));
+        Assert.True(_fs.Exists("/s2.txt"));
+        Assert.Contains("missing.txt", result.Stderr, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Head_ShowsFirstLines()
     {
         _fs.WriteFile("/lines.txt", "line1\nline2\nline3\nline4\nline5");
@@ -260,6 +317,19 @@ public class SandboxShellTests
     }
 
     [Fact]
+    public void Head_MultipleFiles_LaterFailure_KeepsPriorOutputBeforeFailure()
+    {
+        _fs.WriteFile("/a.txt", "A1\nA2");
+        _fs.WriteFile("/c.txt", "C1\nC2");
+
+        var result = _shell.Execute("head -n 1 /a.txt /missing.txt /c.txt");
+
+        Assert.False(result.Success);
+        Assert.Equal("A1", result.Stdout.Replace("\r\n", "\n"));
+        Assert.Contains("missing.txt", result.Stderr, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Tail_ShowsLastLines()
     {
         _fs.WriteFile("/lines.txt", "line1\nline2\nline3\nline4\nline5");
@@ -292,6 +362,19 @@ public class SandboxShellTests
 
         Assert.True(result.Success);
         Assert.Equal(string.Empty, result.Stdout);
+    }
+
+    [Fact]
+    public void Tail_MultipleFiles_LaterFailure_KeepsPriorOutputBeforeFailure()
+    {
+        _fs.WriteFile("/a.txt", "A1\nA2");
+        _fs.WriteFile("/c.txt", "C1\nC2");
+
+        var result = _shell.Execute("tail -n 1 /a.txt /missing.txt /c.txt");
+
+        Assert.False(result.Success);
+        Assert.Equal("A2", result.Stdout.Replace("\r\n", "\n"));
+        Assert.Contains("missing.txt", result.Stderr, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -399,6 +482,20 @@ public class SandboxShellTests
 
         Assert.False(result.Success);
         Assert.Contains("grep: missing pattern or file", result.Stderr, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Grep_MultipleFiles_LaterFailure_KeepsPriorOutputBeforeFailure()
+    {
+        _fs.WriteFile("/a.txt", "apple\nbanana");
+        _fs.WriteFile("/c.txt", "apple");
+
+        var result = _shell.Execute("grep apple /a.txt /missing.txt /c.txt");
+
+        Assert.False(result.Success);
+        Assert.Contains("/a.txt:apple", result.Stdout, StringComparison.Ordinal);
+        Assert.DoesNotContain("/c.txt:apple", result.Stdout, StringComparison.Ordinal);
+        Assert.Contains("missing.txt", result.Stderr, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -758,6 +855,21 @@ public class SandboxShellTests
         Assert.True(result.Success);
         Assert.Contains("3", result.Stdout, StringComparison.Ordinal);
         Assert.Contains("/windows.txt", result.Stdout, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Wc_MultipleFiles_LaterFailure_KeepsPriorOutputBeforeFailure()
+    {
+        _fs.WriteFile("/a.txt", "one\ntwo");
+        _fs.WriteFile("/c.txt", "three");
+
+        var result = _shell.Execute("wc /a.txt /missing.txt /c.txt");
+
+        Assert.False(result.Success);
+        Assert.Contains("/a.txt", result.Stdout, StringComparison.Ordinal);
+        Assert.DoesNotContain("total", result.Stdout, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("/c.txt", result.Stdout, StringComparison.Ordinal);
+        Assert.Contains("missing.txt", result.Stderr, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #123

## Summary
- centralize multi-target fail-fast handling via `MultiTargetCommandFailurePolicy`
- align command behavior across cat/cp/mv/head/tail/wc/grep/ls/rm with explicit partial-output and side-effect semantics
- add cross-command consistency tests for mixed success/failure sequences
- document multi-file policy matrix in AgentSandbox.Core README

## Verification
- dotnet test tests/AgentSandbox.Tests/AgentSandbox.Tests.csproj --filter "FullyQualifiedName~SandboxShellTests"
- dotnet test AgentSandbox.sln