### PR TITLE
Area 2: harden sandbox file system I/O contracts

### DIFF
--- a/AgentSandbox.Core/README.md
+++ b/AgentSandbox.Core/README.md
@@ -93,6 +93,7 @@ var sandbox = new Sandbox("agent-1", options);
 ```
 
 `ReadFileLines`, `WriteFile`, and `ApplyPatch` reject path inputs that contain `..` traversal segments.
+`ReadFileLines` returns a materialized line snapshot captured at call time (it is not a lazy streaming cursor).
 
 ### Secret Policy Model
 

--- a/AgentSandbox.Core/Sandbox.cs
+++ b/AgentSandbox.Core/Sandbox.cs
@@ -397,8 +397,8 @@ public class Sandbox : IDisposable, IObservableSandbox
     #region File System I/O
 
     /// <summary>
-    /// Reads file lines within a range as a lazy-evaluated stream.
-    /// Useful for reading specific line ranges from large files without materializing the entire file.
+    /// Reads file lines within a range and returns a materialized snapshot.
+    /// The returned enumerable is detached from future file mutations.
     /// </summary>
     /// <param name="path">Path to the file to read.</param>
     /// <param name="startLine">Starting line number (1-indexed), inclusive. If null, defaults to 1.</param>
@@ -407,8 +407,7 @@ public class Sandbox : IDisposable, IObservableSandbox
     /// <remarks>
     /// - Line numbers are 1-indexed (first line = 1)
     /// - endLine is exclusive (startLine=1, endLine=4 returns lines 1, 2, 3)
-    /// - Lines are yielded lazily as they're encountered during scanning
-    /// - Enumeration stops as soon as endLine is reached (early termination)
+    /// - Results are materialized before return to keep telemetry and locking deterministic
     /// </remarks>
     /// <exception cref="FileNotFoundException">File does not exist.</exception>
     /// <exception cref="InvalidOperationException">Path is a directory.</exception>

--- a/tests/AgentSandbox.Tests/SandboxConcurrencyTests.cs
+++ b/tests/AgentSandbox.Tests/SandboxConcurrencyTests.cs
@@ -78,6 +78,58 @@ public class SandboxConcurrencyTests
     }
 
     [Fact]
+    public async Task ConcurrentReadAndWrite_AreSerializedWithoutConflictErrors()
+    {
+        using var sandbox = new Sandbox();
+        sandbox.WriteFile("/shared.txt", "seed");
+        using var start = new ManualResetEventSlim(false);
+
+        Exception? readFailure = null;
+        Exception? writeFailure = null;
+
+        var reader = Task.Run(() =>
+        {
+            Assert.True(start.Wait(TimeSpan.FromSeconds(1)));
+            try
+            {
+                for (var i = 0; i < 200; i++)
+                {
+                    _ = sandbox.ReadFileLines("/shared.txt").ToArray();
+                }
+            }
+            catch (Exception ex)
+            {
+                readFailure = ex;
+            }
+        });
+
+        var writer = Task.Run(() =>
+        {
+            Assert.True(start.Wait(TimeSpan.FromSeconds(1)));
+            try
+            {
+                for (var i = 0; i < 100; i++)
+                {
+                    sandbox.WriteFile("/shared.txt", $"value-{i}");
+                }
+            }
+            catch (Exception ex)
+            {
+                writeFailure = ex;
+            }
+        });
+
+        start.Set();
+        await Task.WhenAll(reader, writer);
+
+        Assert.Null(readFailure);
+        Assert.Null(writeFailure);
+
+        var persisted = string.Join("\n", sandbox.ReadFileLines("/shared.txt"));
+        Assert.StartsWith("value-", persisted, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Timeout_BlocksSubsequentOperationsUntilBackgroundCommandCompletes()
     {
         using var sandbox = new Sandbox(options: new SandboxOptions

--- a/tests/AgentSandbox.Tests/SandboxFileIOTests.cs
+++ b/tests/AgentSandbox.Tests/SandboxFileIOTests.cs
@@ -202,6 +202,18 @@ public class SandboxFileIOTests : IDisposable
         Assert.Equal("Middle", lines[2]);
     }
 
+    [Fact]
+    public void ReadFileLines_ReturnsMaterializedSnapshot_IndependentOfSubsequentWrites()
+    {
+        _sandbox.WriteFile("/snapshot.txt", "line 1\nline 2");
+
+        var snapshot = _sandbox.ReadFileLines("/snapshot.txt");
+
+        _sandbox.WriteFile("/snapshot.txt", "changed");
+
+        Assert.Equal(["line 1", "line 2"], snapshot.ToArray());
+    }
+
     #endregion
 
     #region Lazy Line Scanning Tests (comprehensive coverage)
@@ -668,6 +680,22 @@ public class SandboxFileIOTests : IDisposable
 ";
 
         Assert.Throws<InvalidOperationException>(() => _sandbox.ApplyPatch("/file.txt", patch));
+    }
+
+    [Fact]
+    public void ApplyPatch_ThrowsArgumentException_OnInvalidHunkHeader()
+    {
+        _sandbox.WriteFile("/file.txt", "Line 1");
+
+        var patch = @"--- a/file.txt
++++ b/file.txt
+@@ invalid hunk @@
+ Line 1
+";
+
+        var ex = Assert.Throws<ArgumentException>(() => _sandbox.ApplyPatch("/file.txt", patch));
+
+        Assert.Contains("Invalid hunk header", ex.Message, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/AgentSandbox.Tests/SandboxValidationTests.cs
+++ b/tests/AgentSandbox.Tests/SandboxValidationTests.cs
@@ -53,6 +53,19 @@ public class SandboxValidationTests
     }
 
     [Fact]
+    public void WriteFile_ThrowsDeterministicErrorCode_WhenPayloadTooLarge_WithMultiByteUtf8()
+    {
+        using var sandbox = new Sandbox(options: new SandboxOptions
+        {
+            MaxWritePayloadBytes = 4
+        });
+
+        var ex = Assert.Throws<CoreValidationException>(() => sandbox.WriteFile("/a.txt", "😀😀"));
+
+        Assert.Equal(CoreValidationErrorCodes.WritePayloadTooLarge, ex.ErrorCode);
+    }
+
+    [Fact]
     public void WriteFile_ThrowsArgumentNullException_WhenContentIsNull()
     {
         using var sandbox = new Sandbox();


### PR DESCRIPTION
Closes #146

## Summary
- align `ReadFileLines` docs with materialized snapshot semantics
- add regression tests for materialized snapshot behavior, malformed patch hunk diagnostics, and UTF-8 multibyte write payload limits
- add concurrent read/write serialization coverage for file lanes

## Plan-document archive requirement
The Area 2 plan docs are maintained in the orchestration workspace docs set:
- `docs/SANDBOX_HARDENING_PLAN_2_FILE_SYSTEM_IO.md`
- `docs/SANDBOX_CORE_HARDENING_PLAN_OVERVIEW.md`

This PR covers Area 2 implementation and tests. The archive step is tracked by issue requirement and will be completed in the issue-completion workflow, with the issue thread updated to include the archived location reference.