### PR TITLE
fix(sql): validate InMemorySqlDataSource ColumnTypes

### DIFF
--- a/AgentSandbox.Capabilities.SQL/InMemorySqlDataSource.cs
+++ b/AgentSandbox.Capabilities.SQL/InMemorySqlDataSource.cs
@@ -7,6 +7,14 @@ public sealed class InMemorySqlDataSource : IDisposable
 {
     private static readonly Regex IdentifierRegex = new("^[A-Za-z_][A-Za-z0-9_]*$", RegexOptions.Compiled);
     private static readonly Regex DataSourceNameRegex = new("^[A-Za-z0-9_.-]+$", RegexOptions.Compiled);
+    private static readonly HashSet<string> AllowedColumnTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "TEXT",
+        "INTEGER",
+        "REAL",
+        "BLOB",
+        "NUMERIC"
+    };
     private readonly SqliteConnection _keeperConnection;
     private readonly string _connectionString;
     private bool _disposed;
@@ -58,6 +66,7 @@ public sealed class InMemorySqlDataSource : IDisposable
         {
             ValidateIdentifier(column, "rows");
         }
+        var normalizedColumnTypes = ValidateAndNormalizeColumnTypes(options.ColumnTypes, columns);
 
         await using var connection = CreateConnection();
         await connection.OpenAsync(cancellationToken);
@@ -65,7 +74,7 @@ public sealed class InMemorySqlDataSource : IDisposable
 
         if (options.CreateIfNotExists)
         {
-            await CreateTableIfNeededAsync(connection, transaction, table, firstRow, options, cancellationToken);
+            await CreateTableIfNeededAsync(connection, transaction, table, firstRow, normalizedColumnTypes, cancellationToken);
         }
 
         await InsertRowAsync(connection, transaction, table, columns, firstRow, cancellationToken);
@@ -95,12 +104,12 @@ public sealed class InMemorySqlDataSource : IDisposable
         SqliteTransaction transaction,
         string table,
         IReadOnlyDictionary<string, object?> firstRow,
-        InsertRowsOptions options,
+        IReadOnlyDictionary<string, string>? columnTypes,
         CancellationToken cancellationToken)
     {
         var columnDefinitions = firstRow.Select(pair =>
         {
-            var type = ResolveColumnType(pair.Key, pair.Value, options.ColumnTypes);
+            var type = ResolveColumnType(pair.Key, pair.Value, columnTypes);
             return $"{QuoteIdentifier(pair.Key)} {type}";
         });
 
@@ -151,6 +160,48 @@ public sealed class InMemorySqlDataSource : IDisposable
             float or double or decimal => "REAL",
             _ => "TEXT"
         };
+    }
+
+    private static IReadOnlyDictionary<string, string>? ValidateAndNormalizeColumnTypes(
+        IReadOnlyDictionary<string, string>? overrides,
+        IReadOnlyCollection<string> rowColumns)
+    {
+        if (overrides is null || overrides.Count == 0)
+        {
+            return overrides;
+        }
+
+        var knownColumns = new HashSet<string>(rowColumns, StringComparer.OrdinalIgnoreCase);
+        var normalized = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var pair in overrides)
+        {
+            ValidateIdentifier(pair.Key, nameof(InsertRowsOptions.ColumnTypes));
+            if (!knownColumns.Contains(pair.Key))
+            {
+                throw new ArgumentException(
+                    $"ColumnTypes override column '{pair.Key}' does not exist in row data.",
+                    nameof(InsertRowsOptions.ColumnTypes));
+            }
+
+            if (string.IsNullOrWhiteSpace(pair.Value))
+            {
+                throw new ArgumentException(
+                    $"ColumnTypes override for column '{pair.Key}' must be non-empty.",
+                    nameof(InsertRowsOptions.ColumnTypes));
+            }
+
+            var normalizedType = pair.Value.Trim().ToUpperInvariant();
+            if (!AllowedColumnTypes.Contains(normalizedType))
+            {
+                throw new ArgumentException(
+                    $"ColumnTypes override for column '{pair.Key}' has unsupported type '{pair.Value}'. Allowed types: TEXT, INTEGER, REAL, BLOB, NUMERIC.",
+                    nameof(InsertRowsOptions.ColumnTypes));
+            }
+
+            normalized[pair.Key] = normalizedType;
+        }
+
+        return normalized;
     }
 
     private static string QuoteIdentifier(string identifier) => $"\"{identifier}\"";

--- a/AgentSandbox.Capabilities.SQL/InMemorySqlDataSource.cs
+++ b/AgentSandbox.Capabilities.SQL/InMemorySqlDataSource.cs
@@ -166,13 +166,14 @@ public sealed class InMemorySqlDataSource : IDisposable
         IReadOnlyDictionary<string, string>? overrides,
         IReadOnlyCollection<string> rowColumns)
     {
-        if (overrides is null || overrides.Count == 0)
+        if (overrides is null)
         {
-            return overrides;
+            return null;
         }
 
         var knownColumns = new HashSet<string>(rowColumns, StringComparer.OrdinalIgnoreCase);
         var normalized = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var allowedTypes = string.Join(", ", AllowedColumnTypes.OrderBy(type => type, StringComparer.OrdinalIgnoreCase));
         foreach (var pair in overrides)
         {
             ValidateIdentifier(pair.Key, nameof(InsertRowsOptions.ColumnTypes));
@@ -194,11 +195,16 @@ public sealed class InMemorySqlDataSource : IDisposable
             if (!AllowedColumnTypes.Contains(normalizedType))
             {
                 throw new ArgumentException(
-                    $"ColumnTypes override for column '{pair.Key}' has unsupported type '{pair.Value}'. Allowed types: TEXT, INTEGER, REAL, BLOB, NUMERIC.",
+                    $"ColumnTypes override for column '{pair.Key}' has unsupported type '{pair.Value}'. Allowed types: {allowedTypes}.",
                     nameof(InsertRowsOptions.ColumnTypes));
             }
 
-            normalized[pair.Key] = normalizedType;
+            if (!normalized.TryAdd(pair.Key, normalizedType))
+            {
+                throw new ArgumentException(
+                    $"ColumnTypes contains duplicate column override '{pair.Key}' that differs only by casing.",
+                    nameof(InsertRowsOptions.ColumnTypes));
+            }
         }
 
         return normalized;

--- a/AgentSandbox.Capabilities.SQL/README.md
+++ b/AgentSandbox.Capabilities.SQL/README.md
@@ -40,6 +40,8 @@ var capability = new SqlSandboxCapability(new SqlCapabilityOptions
 });
 ```
 
+`InsertRowsOptions.ColumnTypes` accepts only SQLite affinity names: `TEXT`, `INTEGER`, `REAL`, `BLOB`, `NUMERIC`.
+
 ## Read-only policy
 
 - Allowed statement categories: `SELECT`, read-only `WITH ... SELECT` (including `AS MATERIALIZED` / `AS NOT MATERIALIZED` CTE modifiers), read `EXPLAIN`, read `PRAGMA`

--- a/tests/AgentSandbox.Tests/InMemorySqlDataSourceTests.cs
+++ b/tests/AgentSandbox.Tests/InMemorySqlDataSourceTests.cs
@@ -187,6 +187,31 @@ public class InMemorySqlDataSourceTests
         Assert.Contains("missing", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public async Task InsertRowsAsync_Throws_WhenColumnTypeOverridesDuplicateByCase()
+    {
+        using var dataSource = new InMemorySqlDataSource();
+
+        var ex = await Assert.ThrowsAsync<ArgumentException>(async () =>
+            await dataSource.InsertRowsAsync(
+                table: "requests",
+                rows: ToAsyncRows(new List<IReadOnlyDictionary<string, object?>>
+                {
+                    new Dictionary<string, object?> { ["payload"] = "{\"ok\":true}" }
+                }),
+                options: new InsertRowsOptions
+                {
+                    CreateIfNotExists = true,
+                    ColumnTypes = new Dictionary<string, string>
+                    {
+                        ["payload"] = "TEXT",
+                        ["Payload"] = "BLOB"
+                    }
+                }));
+
+        Assert.Contains("duplicate", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
     [Theory]
     [InlineData("TEXT", "TEXT")]
     [InlineData("integer", "INTEGER")]

--- a/tests/AgentSandbox.Tests/InMemorySqlDataSourceTests.cs
+++ b/tests/AgentSandbox.Tests/InMemorySqlDataSourceTests.cs
@@ -140,6 +140,89 @@ public class InMemorySqlDataSourceTests
         Assert.Equal("BLOB", types["payload"]);
     }
 
+    [Theory]
+    [InlineData("TEXT); DROP TABLE requests; --")]
+    [InlineData("VARCHAR(255)")]
+    [InlineData("INTEGER PRIMARY KEY")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task InsertRowsAsync_Throws_ForInvalidColumnTypeOverrides(string overrideType)
+    {
+        using var dataSource = new InMemorySqlDataSource();
+
+        var ex = await Assert.ThrowsAsync<ArgumentException>(async () =>
+            await dataSource.InsertRowsAsync(
+                table: "requests",
+                rows: ToAsyncRows(new List<IReadOnlyDictionary<string, object?>>
+                {
+                    new Dictionary<string, object?> { ["result_code"] = "200", ["payload"] = "{\"ok\":true}" }
+                }),
+                options: new InsertRowsOptions
+                {
+                    CreateIfNotExists = true,
+                    ColumnTypes = new Dictionary<string, string> { ["payload"] = overrideType }
+                }));
+
+        Assert.Contains("payload", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task InsertRowsAsync_Throws_WhenColumnTypeOverrideReferencesUnknownColumn()
+    {
+        using var dataSource = new InMemorySqlDataSource();
+
+        var ex = await Assert.ThrowsAsync<ArgumentException>(async () =>
+            await dataSource.InsertRowsAsync(
+                table: "requests",
+                rows: ToAsyncRows(new List<IReadOnlyDictionary<string, object?>>
+                {
+                    new Dictionary<string, object?> { ["payload"] = "{\"ok\":true}" }
+                }),
+                options: new InsertRowsOptions
+                {
+                    CreateIfNotExists = true,
+                    ColumnTypes = new Dictionary<string, string> { ["missing"] = "TEXT" }
+                }));
+
+        Assert.Contains("missing", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("TEXT", "TEXT")]
+    [InlineData("integer", "INTEGER")]
+    [InlineData(" Real ", "REAL")]
+    [InlineData("numeric", "NUMERIC")]
+    [InlineData("BLOB", "BLOB")]
+    public async Task InsertRowsAsync_AllowsSupportedColumnTypeOverrides(string overrideType, string expectedSchemaType)
+    {
+        using var dataSource = new InMemorySqlDataSource();
+        await dataSource.InsertRowsAsync(
+            table: "requests",
+            rows: ToAsyncRows(new List<IReadOnlyDictionary<string, object?>>
+            {
+                new Dictionary<string, object?> { ["payload"] = "x" }
+            }),
+            options: new InsertRowsOptions
+            {
+                CreateIfNotExists = true,
+                ColumnTypes = new Dictionary<string, string> { ["payload"] = overrideType }
+            });
+
+        await using var connection = dataSource.CreateConnection();
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = "PRAGMA table_info(requests)";
+        await using var reader = await command.ExecuteReaderAsync();
+
+        var types = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        while (await reader.ReadAsync())
+        {
+            types[reader.GetString(1)] = reader.GetString(2);
+        }
+
+        Assert.Equal(expectedSchemaType, types["payload"]);
+    }
+
     [Fact]
     public async Task DataSource_Throws_WhenUsedAfterDispose()
     {


### PR DESCRIPTION
Closes #158

## Summary
- validate and normalize InsertRowsOptions.ColumnTypes using a strict allowlist (TEXT, INTEGER, REAL, BLOB, NUMERIC)
- reject unknown override columns not present in row data and reject invalid/unsafe type strings with clear argument exceptions
- add regression coverage for invalid types, supported types, and unknown-column overrides